### PR TITLE
adjusted ncolors for endless and 1P time attack

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -17,6 +17,12 @@ Stack = class(function(s, which, mode, speed, difficulty)
     if mode ~= "puzzle" then
       s.do_first_row = true
     end
+	if s.mode == "endless" then
+		s.NCOLORS = difficulty_to_ncolors_endless[difficulty]
+	end
+	if s.mode == "time" then
+		s.NCOLORS = difficulty_to_ncolors_1Ptime[difficulty]
+	end
 
     if s.mode == "2ptime" or s.mode == "vs" then
       local level = speed or 5

--- a/globals.lua
+++ b/globals.lua
@@ -66,6 +66,9 @@ stop_time_combo =  {120, 120, 120}
 stop_time_chain =  {300, 180, 120}
 stop_time_danger = {600, 420, 240}
 
+difficulty_to_ncolors_endless = {5,6,6}
+difficulty_to_ncolors_1Ptime = {6,6,6}
+
 -- Yes, 2 is slower than 1 and 50..99 are the same.
 speed_to_rise_time = map(function(x) return x/16 end,
    {942, 983, 838, 790, 755, 695, 649, 604, 570, 515,


### PR DESCRIPTION
set number of colors for endless to 5 on easy, 6 on normal or hard.
set number of colors for 1p time attack to 6 always.  PdP gives you 6 colors in this mode, even on easy.